### PR TITLE
[Feat] 폴더 생성 기능 구현 (#13)

### DIFF
--- a/drive/src/main/java/com/Dolmeng_E/drive/common/StringPrefixedSequenceIdGenerator.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/common/StringPrefixedSequenceIdGenerator.java
@@ -1,0 +1,32 @@
+package com.Dolmeng_E.drive.common;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.Type;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+// Custom ID Generator 클래스
+public class StringPrefixedSequenceIdGenerator extends SequenceStyleGenerator {
+
+    public static final String VALUE_PREFIX_PARAMETER = "valuePrefix";
+    private String valuePrefix;
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+        // valuePrefix(예: "ws")와 DB 시퀀스 값을 조합하여 ID 생성
+        return valuePrefix + super.generate(session, object);
+    }
+
+    @Override
+    public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) {
+        super.configure(new TypeConfiguration().getBasicTypeRegistry().getRegisteredType(Long.class), params, serviceRegistry);
+        // Entity에서 @Parameter 로 넘겨준 valuePrefix 값을 읽어옴
+        this.valuePrefix = ConfigurationHelper.getString(VALUE_PREFIX_PARAMETER, params);
+    }
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/common/domain/BaseTimeEntity.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/common/domain/BaseTimeEntity.java
@@ -1,0 +1,20 @@
+package com.Dolmeng_E.drive.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/common/dto/CommonErrorDto.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/common/dto/CommonErrorDto.java
@@ -1,0 +1,15 @@
+package com.Dolmeng_E.drive.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommonErrorDto {
+    private int statusCode;
+    private String statusMessage;
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/common/dto/CommonSuccessDto.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/common/dto/CommonSuccessDto.java
@@ -1,0 +1,16 @@
+package com.Dolmeng_E.drive.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommonSuccessDto {
+    private Object result;
+    private int statusCode;
+    private String statusMessage;
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/common/service/CommonExceptionHandler.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/common/service/CommonExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.Dolmeng_E.drive.common.service;
+
+import com.Dolmeng_E.drive.common.dto.CommonErrorDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class CommonExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    // 상황에 따라 다른 에러가 파라미터로 주입됨
+    public ResponseEntity<?> illegalException(IllegalArgumentException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ResponseEntity<>(new CommonErrorDto(HttpStatus.BAD_REQUEST.value(), e.getMessage())
+                , HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> entityNotFoundException(EntityNotFoundException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ResponseEntity<>(new CommonErrorDto(HttpStatus.NOT_FOUND.value(), e.getMessage())
+                , HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        String errorMessage = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        return new ResponseEntity<>(new CommonErrorDto(HttpStatus.BAD_REQUEST.value(), errorMessage)
+                , HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> exception(Exception e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ResponseEntity<>(new CommonErrorDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage())
+                , HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/controller/FolderController.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/controller/FolderController.java
@@ -1,0 +1,31 @@
+package com.Dolmeng_E.drive.domain.folder.controller;
+
+import com.Dolmeng_E.drive.common.dto.CommonSuccessDto;
+import com.Dolmeng_E.drive.domain.folder.dto.CreateFolderDto;
+import com.Dolmeng_E.drive.domain.folder.entity.Folder;
+import com.Dolmeng_E.drive.domain.folder.service.FolderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/folder")
+@RequiredArgsConstructor
+public class FolderController {
+
+    private final FolderService folderService;
+
+    // 폴더 생성
+    @PostMapping("")
+    public ResponseEntity<?> createFolder(@RequestBody CreateFolderDto createFolderDto) {
+        return new ResponseEntity<>(CommonSuccessDto.builder()
+                .result(folderService.createFolder(createFolderDto))
+                .statusCode(HttpStatus.CREATED.value())
+                .statusMessage("폴더 생성 성공")
+                .build(), HttpStatus.CREATED);
+    }
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/dto/CreateFolderDto.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/dto/CreateFolderDto.java
@@ -1,0 +1,32 @@
+package com.Dolmeng_E.drive.domain.folder.dto;
+
+import com.Dolmeng_E.drive.domain.folder.entity.Folder;
+import com.Dolmeng_E.drive.domain.folder.entity.RootType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateFolderDto {
+    private String name;
+    private String workspaceId;
+    private String rootId;
+    private RootType rootType;
+    private String parentId;
+    private String createdBy;
+
+    public Folder toEntity(){
+        return Folder.builder()
+                .name(name)
+                .workspaceId(workspaceId)
+                .rootId(rootId)
+                .rootType(rootType)
+                .parentId(parentId)
+                .createdBy(createdBy)
+                .build();
+    }
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/entity/Folder.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/entity/Folder.java
@@ -1,0 +1,51 @@
+package com.Dolmeng_E.drive.domain.folder.entity;
+
+import com.Dolmeng_E.drive.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Folder extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "folder_seq")
+    @GenericGenerator(
+            name = "folder_seq", // generator 이름
+            strategy = "com.Dolmeng_E.drive.common.StringPrefixedSequenceIdGenerator", // 1단계에서 만든 클래스 경로
+            parameters = {
+                    @Parameter(name = "sequence_name", value = "folder_seq"), // DB에 생성할 시퀀스 이름
+                    @Parameter(name = "initial_value", value = "1"), // 시퀀스 시작 값
+                    @Parameter(name = "increment_size", value = "1"), // 시퀀스 증가 값
+                    @Parameter(name = "valuePrefix", value = "ws_fol_") // ID에 붙일 접두사!
+            }
+    )
+    private String id;
+
+    @Column(nullable = false)
+    private String workspaceId;
+
+    private String rootId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RootType rootType;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String parentId;
+
+    @Column(nullable = false)
+    private String createdBy;
+
+    private String updatedBy;
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/entity/RootType.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/entity/RootType.java
@@ -1,0 +1,5 @@
+package com.Dolmeng_E.drive.domain.folder.entity;
+
+public enum RootType {
+    WORKSPACE, PROJECT, STONE
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/repository/FolderRepository.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/repository/FolderRepository.java
@@ -1,0 +1,12 @@
+package com.Dolmeng_E.drive.domain.folder.repository;
+
+import com.Dolmeng_E.drive.domain.folder.entity.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FolderRepository extends JpaRepository<Folder, String> {
+    Optional<Folder> findByParentIdAndName(String parentId, String name);
+}

--- a/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/service/FolderService.java
+++ b/drive/src/main/java/com/Dolmeng_E/drive/domain/folder/service/FolderService.java
@@ -1,0 +1,25 @@
+package com.Dolmeng_E.drive.domain.folder.service;
+
+import com.Dolmeng_E.drive.domain.folder.dto.CreateFolderDto;
+import com.Dolmeng_E.drive.domain.folder.entity.Folder;
+import com.Dolmeng_E.drive.domain.folder.repository.FolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static jakarta.persistence.GenerationType.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FolderService {
+
+    private final FolderRepository folderRepository;
+
+    public String createFolder(CreateFolderDto createFolderDto){
+        if(folderRepository.findByParentIdAndName(createFolderDto.getParentId(), createFolderDto.getName()).isPresent()){
+            throw new IllegalArgumentException("중복된 폴더명입니다.");
+        }
+        return folderRepository.save(createFolderDto.toEntity()).getId();
+    }
+}


### PR DESCRIPTION
- 폴더 생성 API 및 서비스 로직 추가

### 📋 작업 개요
- 폴더 Entity/Service/Respository 구현
- 폴더 생성 API 개발

<br/>


### 🔧 작업 상세
- 상위 폴더와 폴더 이름 중복 체크하여 해당 폴더에 중복된 이름을 가진 폴더를 체크하는 로직 추가
- 폴더 생성 시 폴더 ID 반환
- 실패 시 커스텀 예외 반환

<br/>


### 📌 이슈 번호
- close #13 
 
<br/>


### ⚠️ 참고사항
- 워크스페이스/생성위치/워크스페이스 참여자 연결 필요
- postman에서 http://localhost:8080/drive-service/folder로 확인 가능
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
