### PR TITLE
[Refactor] 워크스페이스 로직 개선 (#90)

### DIFF
--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/repository/ProjectRepository.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/repository/ProjectRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, String> {
-    List<Project> findAllByWorkspaceIdAndIsDeletedFalseAndProjectStatusNot(String workspaceId, ProjectStatus projectStatus);
+    List<Project> findAllByWorkspaceIdAndIsDeleteFalseAndProjectStatusNot(String workspaceId, ProjectStatus projectStatus);
 }

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/service/ProjectService.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/service/ProjectService.java
@@ -114,7 +114,7 @@ public class ProjectService {
                 .orElseThrow(()->new EntityNotFoundException("워크스페이스 참여자가 아닙니다."));
 
         // 2. dto 조립, 진행중,완료인 프로젝트만 보기
-        List<Project> projectlist = projectRepository.findAllByWorkspaceIdAndIsDeletedFalseAndProjectStatusNot(workspaceId, ProjectStatus.PROGRESS);
+        List<Project> projectlist = projectRepository.findAllByWorkspaceIdAndIsDeleteFalseAndProjectStatusNot(workspaceId, ProjectStatus.PROGRESS);
         List<ProjectListDto> projectListDtoList = projectlist.stream().map(ProjectListDto::fromEntity).toList();
         return projectListDtoList;
     }

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/controller/WorkspaceController.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/controller/WorkspaceController.java
@@ -145,4 +145,17 @@ public class WorkspaceController {
                 HttpStatus.OK);
     }
 
+    @DeleteMapping("/{workspaceId}")
+    public ResponseEntity<?> deleteWorkspace(@RequestHeader("X-User-Id") String userId,
+                                             @PathVariable String workspaceId
+    ) {
+        workspaceService.deleteWorkspace(userId,workspaceId);
+        return new ResponseEntity<>(CommonSuccessDto.builder()
+                .statusCode(HttpStatus.OK.value())
+                .statusMessage("워크스페이스 회원 삭제 성공")
+                .result(HttpStatus.OK)
+                .build(),
+                HttpStatus.OK);
+    }
+
 }

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/dto/WorkspaceParticipantResDto.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/dto/WorkspaceParticipantResDto.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 public class WorkspaceParticipantResDto {
     private UUID userId;
     private String userName;
+    private String workspaceParticipantId;
     private String workspaceRole;
     private String accessGroupId;
     private String accessGroupName;

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/entity/Workspace.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/entity/Workspace.java
@@ -40,6 +40,10 @@ public class Workspace extends BaseTimeEntity {
     @Column(length = 20)
     private String workspaceName;
 
+    @Builder.Default
+    @Column(name = "is_delete")
+    private Boolean isDelete = false;
+
 //    결제 구현 완료 시 구독개월 활용 예정
     private Integer subscribe;
 
@@ -62,6 +66,10 @@ public class Workspace extends BaseTimeEntity {
 
     public void updateWorkspaceName(String newName) {
         this.workspaceName = newName;
+    }
+
+    public void deleteWorkspace() {
+        this.isDelete = true;
     }
 
 }

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/entity/WorkspaceParticipant.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/entity/WorkspaceParticipant.java
@@ -60,8 +60,8 @@ public class WorkspaceParticipant extends BaseTimeEntity {
         return isDelete;
     }
 
-    public void setDelete(boolean delete) {
-        this.isDelete = delete;
+    public void deleteParticipant() {
+        this.isDelete = true;
     }
 
 

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/repository/WorkspaceRepository.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/workspace/repository/WorkspaceRepository.java
@@ -4,6 +4,9 @@ import com.Dolmeng_E.workspace.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface WorkspaceRepository extends JpaRepository<Workspace, String> {
+    Optional<Workspace> findByIdAndIsDeleteFalse(String workspaceId);
 }


### PR DESCRIPTION
### 📋 작업 개요
워크스페이스 로직 리팩토링

<br/>


### 🔧 작업 상세
-워크스페이스 soft delete 구현
-조회 시 softdelete false 항목만 조회 
-워크스페이스 참여자 목록 반환에서 워크스페이스 참여자 id도 반환하도록 dto 추가
-프로젝트 서버에서 오타 수정

<br/>


### 📌 이슈 번호

  `close #90 ` 
<br/>


### ⚠️ 참고사항

#테스트 목록
1. 워크스페이스 삭제 API 추가 (워크스페이스의 관리자만 가능하게 권한 설정) <완료>
2. 워크스페이스 목록조회 시 delete 되지 않은 항목만 보이게 <완료>
3. 워크스페이스 상세조회 시 delete 된 항목은 에러 발생 <완료>
4. 워크스페이스 참여자 목록 조회 시 참여id 추가 <완료> 


<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
