### PR TITLE
[Refactor]스톤 엔티티 컬럼명 변경(#98)

### DIFF
--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/service/ProjectService.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/project/service/ProjectService.java
@@ -127,7 +127,7 @@ public class ProjectService {
                 .orElseThrow(()->new EntityNotFoundException("워크스페이스 참여자가 아닙니다."));
 
         // 2. dto 조립, 진행중,완료인 프로젝트만 보기
-        List<Project> projectlist = projectRepository.findAllByWorkspaceIdAndIsDeleteFalseAndProjectStatusNot(workspaceId, ProjectStatus.PROGRESS);
+        List<Project> projectlist = projectRepository.findAllByWorkspaceIdAndIsDeleteFalseAndProjectStatusNot(workspaceId, ProjectStatus.STORAGE);
         List<ProjectListDto> projectListDtoList = projectlist.stream().map(ProjectListDto::fromEntity).toList();
         return projectListDtoList;
     }

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/stone/entity/Stone.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/stone/entity/Stone.java
@@ -37,7 +37,7 @@ public class Stone extends BaseTimeEntity {
     // 스톤 담당자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stone_manager_id")
-    private WorkspaceParticipant stoneParticipant;
+    private WorkspaceParticipant stoneManager;
 
     // 부모 스톤 (nullable 가능)
     @Column(name = "parent_stone_id")

--- a/workspace/src/main/java/com/Dolmeng_E/workspace/domain/stone/service/StoneService.java
+++ b/workspace/src/main/java/com/Dolmeng_E/workspace/domain/stone/service/StoneService.java
@@ -76,7 +76,7 @@ public class StoneService {
                 .startTime(dto.getStartTime())
                 .endTime(dto.getEndTime())
                 .project(project)
-                .stoneParticipant(participant) //스톤의 담당자
+                .stoneManager(participant) //스톤의 담당자
                 .chatCreation(dto.getChatCreation() != null ? dto.getChatCreation() : false)
                 .taskCreation(false) // 최상위 스톤은 태스크 x
                 .milestone(dto.getMilestone() != null ? dto.getMilestone() : BigDecimal.ZERO) // 최초 마일스톤은 0퍼센트
@@ -143,7 +143,7 @@ public class StoneService {
                         .startTime(dto.getStartTime())
                         .endTime(dto.getEndTime())
                         .project(project)
-                        .stoneParticipant(participant) // 스톤 담당자
+                        .stoneManager(participant) // 스톤 담당자
                         .chatCreation(dto.getChatCreation() != null ? dto.getChatCreation() : false)
                         .parentStoneId(parentStone.getId()) // 상위 스톤 참조
                         .taskCreation(true) // 기본값 true
@@ -200,7 +200,7 @@ public class StoneService {
         // 4. 스톤 관련 권한 검증(프로젝트 담당자와 스톤 담당자만 참여자 추가 가능하도록 혹은 관리자)
         if (!participant.getWorkspaceRole().equals(WorkspaceRole.ADMIN)) {
             if (!project.getWorkspaceParticipant().getId().equals(participant.getId())
-                    && !stone.getStoneParticipant().getId().equals(participant.getId())) {
+                    && !stone.getStoneManager().getId().equals(participant.getId())) {
                 throw new IllegalArgumentException("관리자나 프로젝트 담당자 혹은 스톤 담당자가 아닙니다.");
             }
         }
@@ -281,7 +281,7 @@ public class StoneService {
         // 4. 권한 검증 (프로젝트 담당자 or 스톤 담당자 or 관리자)
         if (!requester.getWorkspaceRole().equals(WorkspaceRole.ADMIN)) {
             if (!project.getWorkspaceParticipant().getId().equals(requester.getId())
-                    && !stone.getStoneParticipant().getId().equals(requester.getId())) {
+                    && !stone.getStoneManager().getId().equals(requester.getId())) {
                 throw new IllegalArgumentException("프로젝트 담당자 혹은 스톤 담당자가 아닙니다.");
             }
         }
@@ -332,7 +332,7 @@ public class StoneService {
         // 4. 권한 검증 (프로젝트 담당자 or 스톤 담당자만 가능)
         if (!participant.getWorkspaceRole().equals(WorkspaceRole.ADMIN)) {
             if (!project.getWorkspaceParticipant().getId().equals(participant.getId())
-                    && !stone.getStoneParticipant().getId().equals(participant.getId())) {
+                    && !stone.getStoneManager().getId().equals(participant.getId())) {
                 throw new IllegalArgumentException("관리자이거나 프로젝트 담당자 혹은 스톤 담당자가 아닙니다.");
             }
         }
@@ -397,7 +397,7 @@ public class StoneService {
         // 4. 스톤 관련 권한 검증(프로젝트 담당자와 스톤 담당자만 참여자 추가 가능하도록)
         if (!participant.getWorkspaceRole().equals(WorkspaceRole.ADMIN)) {
             if (!project.getWorkspaceParticipant().getId().equals(participant.getId())
-                    && !stone.getStoneParticipant().getId().equals(participant.getId())) {
+                    && !stone.getStoneManager().getId().equals(participant.getId())) {
                 throw new IllegalArgumentException("관리자이거나 프로젝트 담당자 혹은 스톤 담당자가 아닙니다.");
             }
         }
@@ -439,7 +439,7 @@ public class StoneService {
         // 4. 권한 검증 (관리자이거나 프로젝트 담당자 또는 기존 스톤 담당자만 가능)
         if (!requester.getWorkspaceRole().equals(WorkspaceRole.ADMIN)) {
             if (!project.getWorkspaceParticipant().getId().equals(requester.getId())
-                    && !stone.getStoneParticipant().getId().equals(requester.getId())) {
+                    && !stone.getStoneManager().getId().equals(requester.getId())) {
                 throw new IllegalArgumentException("관리자나 프로젝트 담당자 혹은 스톤 담당자가 아닙니다.");
             }
         }
@@ -454,7 +454,7 @@ public class StoneService {
         }
 
         // 6. 스톤 담당자 교체
-        stone.setStoneParticipant(newManager);
+        stone.setStoneManager(newManager);
 
         // 7. (선택) 새 담당자가 프로젝트 참여자가 아니라면 자동 등록
         boolean existsInProject = projectParticipantRepository.existsByProjectAndWorkspaceParticipant(project, newManager);


### PR DESCRIPTION
### 📋 작업 개요
스톤 엔티티 컬럼명 변경

<br/>


### 🔧 작업 상세
- 스톤 stoneParticipant -> stoneManager로 필드명 바꿈
- stoneParticipant로 사용하고 있던 서비스 코드 변경
- 프로젝트 목록 조회 코드 수정

<br/>


### 📌 이슈 번호

 `close #100 `
<br/>


### ⚠️ 참고사항

리팩토링 후 포스트맨으로 기존 로직 테스트 완료했습니다.
프로젝트 목록도 잘 나옵니다.

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
