### PR TITLE
Feat: redis에 회원 정보 저장, 수정 구현

### DIFF
--- a/user/src/main/java/com/Dolmeng_E/user/common/config/RedisConfig.java
+++ b/user/src/main/java/com/Dolmeng_E/user/common/config/RedisConfig.java
@@ -29,8 +29,29 @@ public class RedisConfig {
     }
 
     @Bean
+    @Qualifier("userInventory")
+    public RedisConnectionFactory userRedisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        configuration.setDatabase(2);
+
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
     @Qualifier("rtInventory")
     public RedisTemplate<String, String> redisTemplate(@Qualifier("rtInventory") RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    @Qualifier("userInventory")
+    public RedisTemplate<String, String> userRedisTemplate(@Qualifier("userInventory") RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());


### PR DESCRIPTION
### 📋 작업 개요
redis에 회원 정보 저장

<br/>


### 🔧 작업 상세
- 회원가입 시(일반 이메일, kakao, google) redis에 저장
- 회원 수정 시 회원 정보 덮어쓰기
- 회원 삭제 시(soft) isDelete부분 덮어쓰기

<br/>


### 📌 이슈 번호
close #167 
 
<br/>


### ⚠️ 참고사항
hash 자료구조로 저장
예)
key : user:UUID
field: email
value: hong@naver.com

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
